### PR TITLE
Add mapping roundtrip test and id handling

### DIFF
--- a/data/src/main/java/com/parinexus/data/mapper/ArticleMapper.kt
+++ b/data/src/main/java/com/parinexus/data/mapper/ArticleMapper.kt
@@ -4,6 +4,7 @@ import com.parinexus.data.model.DataArticle
 import com.parinexus.domain.model.DomainArticle
 
 fun DataArticle.toDomain(): DomainArticle = DomainArticle(
+    id = id,
     articleId = articleId,
     title = title,
     link = link,
@@ -19,6 +20,7 @@ fun DataArticle.toDomain(): DomainArticle = DomainArticle(
 )
 
 fun DomainArticle.toData(): DataArticle = DataArticle(
+    id = id,
     articleId = articleId,
     title = title,
     link = link,

--- a/data/src/test/java/com/parinexus/data/ExampleUnitTest.kt
+++ b/data/src/test/java/com/parinexus/data/ExampleUnitTest.kt
@@ -1,17 +1,18 @@
 package com.parinexus.data
 
+import com.parinexus.data.mapper.toData
+import com.parinexus.data.mapper.toDomain
+import com.parinexus.data.model.DataArticle
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
-import org.junit.Assert.*
-
-/**
- * Example local unit test, which will execute on the development machine (host).
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 class ExampleUnitTest {
     @Test
-    fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+    fun dataArticle_mapsToDomainAndBack_preservesId() {
+        val original = DataArticle(id = 1, articleId = "a1")
+
+        val mappedBack = original.toDomain().toData()
+
+        assertEquals("ID should be preserved after mapping", original.id, mappedBack.id)
     }
 }


### PR DESCRIPTION
## Summary
- map `id` in `ArticleMapper` so entities keep their Room key
- add a unit test checking that a `DataArticle` keeps its `id` when mapped to `DomainArticle` and back

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ca496a7083209fc316a20132a7b4